### PR TITLE
style(python): Single-line imports

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -2,132 +2,121 @@ import os
 
 from polars import api
 from polars.config import Config
-from polars.convert import (
-    from_arrow,
-    from_dataframe,
-    from_dict,
-    from_dicts,
-    from_numpy,
-    from_pandas,
-    from_records,
-)
-from polars.datatypes import (
-    DATETIME_DTYPES,
-    DURATION_DTYPES,
-    FLOAT_DTYPES,
-    INTEGER_DTYPES,
-    NUMERIC_DTYPES,
-    TEMPORAL_DTYPES,
-    Binary,
-    Boolean,
-    Categorical,
-    DataType,
-    Date,
-    Datetime,
-    Decimal,
-    Duration,
-    Field,
-    Float32,
-    Float64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
-    List,
-    Null,
-    Object,
-    PolarsDataType,
-    Struct,
-    Time,
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
-    Unknown,
-    Utf8,
-)
-from polars.exceptions import (
-    ArrowError,
-    ColumnNotFoundError,
-    ComputeError,
-    DuplicateError,
-    InvalidOperationError,
-    NoDataError,
-    PanicException,
-    SchemaError,
-    SchemaFieldNotFoundError,
-    ShapeError,
-    StructFieldNotFoundError,
-)
+from polars.convert import from_arrow
+from polars.convert import from_dataframe
+from polars.convert import from_dict
+from polars.convert import from_dicts
+from polars.convert import from_numpy
+from polars.convert import from_pandas
+from polars.convert import from_records
+from polars.datatypes import DATETIME_DTYPES
+from polars.datatypes import DURATION_DTYPES
+from polars.datatypes import FLOAT_DTYPES
+from polars.datatypes import INTEGER_DTYPES
+from polars.datatypes import NUMERIC_DTYPES
+from polars.datatypes import TEMPORAL_DTYPES
+from polars.datatypes import Binary
+from polars.datatypes import Boolean
+from polars.datatypes import Categorical
+from polars.datatypes import DataType
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Decimal
+from polars.datatypes import Duration
+from polars.datatypes import Field
+from polars.datatypes import Float32
+from polars.datatypes import Float64
+from polars.datatypes import Int8
+from polars.datatypes import Int16
+from polars.datatypes import Int32
+from polars.datatypes import Int64
+from polars.datatypes import List
+from polars.datatypes import Null
+from polars.datatypes import Object
+from polars.datatypes import PolarsDataType
+from polars.datatypes import Struct
+from polars.datatypes import Time
+from polars.datatypes import UInt8
+from polars.datatypes import UInt16
+from polars.datatypes import UInt32
+from polars.datatypes import UInt64
+from polars.datatypes import Unknown
+from polars.datatypes import Utf8
+from polars.exceptions import ArrowError
+from polars.exceptions import ColumnNotFoundError
+from polars.exceptions import ComputeError
+from polars.exceptions import DuplicateError
+from polars.exceptions import InvalidOperationError
+from polars.exceptions import NoDataError
+from polars.exceptions import PanicException
+from polars.exceptions import SchemaError
+from polars.exceptions import SchemaFieldNotFoundError
+from polars.exceptions import ShapeError
+from polars.exceptions import StructFieldNotFoundError
 
 # TODO remove need for wrap_df
-from polars.internals.dataframe import (
-    DataFrame,
-    wrap_df,  # noqa: F401
-)
+from polars.internals.dataframe import DataFrame
+from polars.internals.dataframe import wrap_df  # noqa: F401
 from polars.internals.expr.expr import Expr
-from polars.internals.functions import (
-    align_frames,
-    concat,
-    cut,
-    date_range,
-    get_dummies,
-    ones,
-    zeros,
-)
-from polars.internals.io import read_ipc_schema, read_parquet_schema
-from polars.internals.lazy_functions import (
-    all,
-    any,
-    apply,
-    arange,
-    arg_sort_by,
-    arg_where,
-    argsort_by,
-    avg,
-    coalesce,
-    col,
-    collect_all,
-    concat_list,
-    concat_str,
-    corr,
-    count,
-    cov,
-    cumfold,
-    cumreduce,
-    cumsum,
-    duration,
-    element,
-    exclude,
-    first,
-    fold,
-    format,
-    from_epoch,
-    groups,
-    head,
-    last,
-    lit,
-    map,
-    max,
-    mean,
-    median,
-    min,
-    n_unique,
-    pearson_corr,
-    quantile,
-    reduce,
-    repeat,
-    select,
-    spearman_rank_corr,
-    std,
-    struct,
-    sum,
-    tail,
-    var,
-)
+from polars.internals.functions import align_frames
+from polars.internals.functions import concat
+from polars.internals.functions import cut
+from polars.internals.functions import date_range
+from polars.internals.functions import get_dummies
+from polars.internals.functions import ones
+from polars.internals.functions import zeros
+from polars.internals.io import read_ipc_schema
+from polars.internals.io import read_parquet_schema
+from polars.internals.lazy_functions import all
+from polars.internals.lazy_functions import any
+from polars.internals.lazy_functions import apply
+from polars.internals.lazy_functions import arange
+from polars.internals.lazy_functions import arg_sort_by
+from polars.internals.lazy_functions import arg_where
+from polars.internals.lazy_functions import argsort_by
+from polars.internals.lazy_functions import avg
+from polars.internals.lazy_functions import coalesce
+from polars.internals.lazy_functions import col
+from polars.internals.lazy_functions import collect_all
+from polars.internals.lazy_functions import concat_list
+from polars.internals.lazy_functions import concat_str
+from polars.internals.lazy_functions import corr
+from polars.internals.lazy_functions import count
+from polars.internals.lazy_functions import cov
+from polars.internals.lazy_functions import cumfold
+from polars.internals.lazy_functions import cumreduce
+from polars.internals.lazy_functions import cumsum
 from polars.internals.lazy_functions import date_ as date
 from polars.internals.lazy_functions import datetime_ as datetime
+from polars.internals.lazy_functions import duration
+from polars.internals.lazy_functions import element
+from polars.internals.lazy_functions import exclude
+from polars.internals.lazy_functions import first
+from polars.internals.lazy_functions import fold
+from polars.internals.lazy_functions import format
+from polars.internals.lazy_functions import from_epoch
+from polars.internals.lazy_functions import groups
+from polars.internals.lazy_functions import head
+from polars.internals.lazy_functions import last
 from polars.internals.lazy_functions import list_ as list
+from polars.internals.lazy_functions import lit
+from polars.internals.lazy_functions import map
+from polars.internals.lazy_functions import max
+from polars.internals.lazy_functions import mean
+from polars.internals.lazy_functions import median
+from polars.internals.lazy_functions import min
+from polars.internals.lazy_functions import n_unique
+from polars.internals.lazy_functions import pearson_corr
+from polars.internals.lazy_functions import quantile
+from polars.internals.lazy_functions import reduce
+from polars.internals.lazy_functions import repeat
+from polars.internals.lazy_functions import select
+from polars.internals.lazy_functions import spearman_rank_corr
+from polars.internals.lazy_functions import std
+from polars.internals.lazy_functions import struct
+from polars.internals.lazy_functions import sum
+from polars.internals.lazy_functions import tail
+from polars.internals.lazy_functions import var
 from polars.internals.lazyframe import LazyFrame
 
 # TODO: remove need for wrap_s
@@ -135,34 +124,32 @@ from polars.internals.series import wrap_s  # noqa: F401
 from polars.internals.series.series import Series
 from polars.internals.sql import SQLContext
 from polars.internals.whenthen import when
-from polars.io import (
-    read_avro,
-    read_csv,
-    read_csv_batched,
-    read_database,
-    read_delta,
-    read_excel,
-    read_ipc,
-    read_json,
-    read_ndjson,
-    read_parquet,
-    read_sql,
-    scan_csv,
-    scan_delta,
-    scan_ds,
-    scan_ipc,
-    scan_ndjson,
-    scan_parquet,
-    scan_pyarrow_dataset,
-)
-from polars.string_cache import StringCache, toggle_string_cache, using_string_cache
-from polars.utils import (
-    build_info,
-    get_idx_type,
-    get_index_type,
-    show_versions,
-    threadpool_size,
-)
+from polars.io import read_avro
+from polars.io import read_csv
+from polars.io import read_csv_batched
+from polars.io import read_database
+from polars.io import read_delta
+from polars.io import read_excel
+from polars.io import read_ipc
+from polars.io import read_json
+from polars.io import read_ndjson
+from polars.io import read_parquet
+from polars.io import read_sql
+from polars.io import scan_csv
+from polars.io import scan_delta
+from polars.io import scan_ds
+from polars.io import scan_ipc
+from polars.io import scan_ndjson
+from polars.io import scan_parquet
+from polars.io import scan_pyarrow_dataset
+from polars.string_cache import StringCache
+from polars.string_cache import toggle_string_cache
+from polars.string_cache import using_string_cache
+from polars.utils import build_info
+from polars.utils import get_idx_type
+from polars.utils import get_index_type
+from polars.utils import show_versions
+from polars.utils import threadpool_size
 from polars.utils.polars_version import get_polars_version as _get_polars_version
 
 __version__: str = _get_polars_version()

--- a/py-polars/polars/api.py
+++ b/py-polars/polars/api.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from functools import reduce
 from operator import or_
-from typing import Callable, TypeVar
+from typing import Callable
+from typing import TypeVar
 from warnings import warn
 
-from polars.internals import DataFrame, Expr, LazyFrame, Series
+from polars.internals import DataFrame
+from polars.internals import Expr
+from polars.internals import LazyFrame
+from polars.internals import Series
 
 __all__ = [
     "register_expr_namespace",

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping, Sequence, overload
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Mapping
+from typing import Sequence
+from typing import overload
 
 from polars.datatypes import N_INFER_DEFAULT
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
-from polars.internals import DataFrame, Series
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.internals import DataFrame
+from polars.internals import Series
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
-    from polars.datatypes import SchemaDefinition, SchemaDict
+    from polars.datatypes import SchemaDefinition
+    from polars.datatypes import SchemaDict
     from polars.dependencies import numpy as np
     from polars.internals.type_aliases import Orientation
 

--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -1,69 +1,59 @@
-from polars.datatypes.classes import (
-    Binary,
-    Boolean,
-    Categorical,
-    DataType,
-    DataTypeClass,
-    Date,
-    Datetime,
-    Decimal,
-    Duration,
-    Field,
-    Float32,
-    Float64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
-    List,
-    Null,
-    Object,
-    Struct,
-    TemporalType,
-    Time,
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
-    Unknown,
-    Utf8,
-)
-from polars.datatypes.constants import (
-    DATETIME_DTYPES,
-    DTYPE_TEMPORAL_UNITS,
-    DURATION_DTYPES,
-    FLOAT_DTYPES,
-    INTEGER_DTYPES,
-    N_INFER_DEFAULT,
-    NUMERIC_DTYPES,
-    TEMPORAL_DTYPES,
-)
-from polars.datatypes.constructor import (
-    numpy_type_to_constructor,
-    numpy_values_and_dtype,
-    polars_type_to_constructor,
-    py_type_to_constructor,
-)
-from polars.datatypes.convert import (
-    dtype_to_arrow_type,
-    dtype_to_ctype,
-    dtype_to_ffiname,
-    dtype_to_py_type,
-    is_polars_dtype,
-    maybe_cast,
-    numpy_char_code_to_dtype,
-    py_type_to_arrow_type,
-    py_type_to_dtype,
-    supported_numpy_char_code,
-)
-from polars.datatypes.type_aliases import (
-    OneOrMoreDataTypes,
-    PolarsDataType,
-    PolarsTemporalType,
-    PythonDataType,
-    SchemaDefinition,
-    SchemaDict,
-)
+from polars.datatypes.classes import Binary
+from polars.datatypes.classes import Boolean
+from polars.datatypes.classes import Categorical
+from polars.datatypes.classes import DataType
+from polars.datatypes.classes import DataTypeClass
+from polars.datatypes.classes import Date
+from polars.datatypes.classes import Datetime
+from polars.datatypes.classes import Decimal
+from polars.datatypes.classes import Duration
+from polars.datatypes.classes import Field
+from polars.datatypes.classes import Float32
+from polars.datatypes.classes import Float64
+from polars.datatypes.classes import Int8
+from polars.datatypes.classes import Int16
+from polars.datatypes.classes import Int32
+from polars.datatypes.classes import Int64
+from polars.datatypes.classes import List
+from polars.datatypes.classes import Null
+from polars.datatypes.classes import Object
+from polars.datatypes.classes import Struct
+from polars.datatypes.classes import TemporalType
+from polars.datatypes.classes import Time
+from polars.datatypes.classes import UInt8
+from polars.datatypes.classes import UInt16
+from polars.datatypes.classes import UInt32
+from polars.datatypes.classes import UInt64
+from polars.datatypes.classes import Unknown
+from polars.datatypes.classes import Utf8
+from polars.datatypes.constants import DATETIME_DTYPES
+from polars.datatypes.constants import DTYPE_TEMPORAL_UNITS
+from polars.datatypes.constants import DURATION_DTYPES
+from polars.datatypes.constants import FLOAT_DTYPES
+from polars.datatypes.constants import INTEGER_DTYPES
+from polars.datatypes.constants import N_INFER_DEFAULT
+from polars.datatypes.constants import NUMERIC_DTYPES
+from polars.datatypes.constants import TEMPORAL_DTYPES
+from polars.datatypes.constructor import numpy_type_to_constructor
+from polars.datatypes.constructor import numpy_values_and_dtype
+from polars.datatypes.constructor import polars_type_to_constructor
+from polars.datatypes.constructor import py_type_to_constructor
+from polars.datatypes.convert import dtype_to_arrow_type
+from polars.datatypes.convert import dtype_to_ctype
+from polars.datatypes.convert import dtype_to_ffiname
+from polars.datatypes.convert import dtype_to_py_type
+from polars.datatypes.convert import is_polars_dtype
+from polars.datatypes.convert import maybe_cast
+from polars.datatypes.convert import numpy_char_code_to_dtype
+from polars.datatypes.convert import py_type_to_arrow_type
+from polars.datatypes.convert import py_type_to_dtype
+from polars.datatypes.convert import supported_numpy_char_code
+from polars.datatypes.type_aliases import OneOrMoreDataTypes
+from polars.datatypes.type_aliases import PolarsDataType
+from polars.datatypes.type_aliases import PolarsTemporalType
+from polars.datatypes.type_aliases import PythonDataType
+from polars.datatypes.type_aliases import SchemaDefinition
+from polars.datatypes.type_aliases import SchemaDict
 
 __all__ = [
     # classes

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import contextlib
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Iterator
+from typing import Mapping
+from typing import Sequence
 
 import polars.datatypes
 
@@ -11,7 +15,9 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 
 if TYPE_CHECKING:
-    from polars.datatypes.type_aliases import PolarsDataType, PythonDataType, SchemaDict
+    from polars.datatypes.type_aliases import PolarsDataType
+    from polars.datatypes.type_aliases import PythonDataType
+    from polars.datatypes.type_aliases import SchemaDict
     from polars.internals.type_aliases import TimeUnit
 
 

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -2,23 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars.datatypes import (
-    Date,
-    Datetime,
-    Decimal,
-    Duration,
-    Float32,
-    Float64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
-    Time,
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
-)
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Decimal
+from polars.datatypes import Duration
+from polars.datatypes import Float32
+from polars.datatypes import Float64
+from polars.datatypes import Int8
+from polars.datatypes import Int16
+from polars.datatypes import Int32
+from polars.datatypes import Int64
+from polars.datatypes import Time
+from polars.datatypes import UInt8
+from polars.datatypes import UInt16
+from polars.datatypes import UInt32
+from polars.datatypes import UInt64
 
 if TYPE_CHECKING:
     from polars.datatypes.type_aliases import PolarsDataType

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from decimal import Decimal as PyDecimal
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Sequence
 
 from polars import datatypes as dt
 from polars.dependencies import numpy as np

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -4,47 +4,46 @@ import ctypes
 import functools
 import re
 import sys
-from datetime import date, datetime, time, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 from decimal import Decimal as PyDecimal
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ForwardRef,
-    Optional,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import ForwardRef
+from typing import Optional
+from typing import TypeVar
+from typing import Union
+from typing import overload
 
-from polars.datatypes import (
-    Binary,
-    Boolean,
-    Categorical,
-    DataType,
-    DataTypeClass,
-    Date,
-    Datetime,
-    Decimal,
-    Duration,
-    Float32,
-    Float64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
-    List,
-    Null,
-    Object,
-    Struct,
-    Time,
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
-    Unknown,
-    Utf8,
-)
+from polars.datatypes import Binary
+from polars.datatypes import Boolean
+from polars.datatypes import Categorical
+from polars.datatypes import DataType
+from polars.datatypes import DataTypeClass
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Decimal
+from polars.datatypes import Duration
+from polars.datatypes import Float32
+from polars.datatypes import Float64
+from polars.datatypes import Int8
+from polars.datatypes import Int16
+from polars.datatypes import Int32
+from polars.datatypes import Int64
+from polars.datatypes import List
+from polars.datatypes import Null
+from polars.datatypes import Object
+from polars.datatypes import Struct
+from polars.datatypes import Time
+from polars.datatypes import UInt8
+from polars.datatypes import UInt16
+from polars.datatypes import UInt32
+from polars.datatypes import UInt64
+from polars.datatypes import Unknown
+from polars.datatypes import Utf8
 from polars.dependencies import numpy as np
 from polars.dependencies import pyarrow as pa
 
@@ -59,14 +58,17 @@ else:
 
 OptionType = type(Optional[type])
 if sys.version_info >= (3, 10):
-    from types import NoneType, UnionType
+    from types import NoneType
+    from types import UnionType
 else:
     # infer equivalent class
     NoneType = type(None)
     UnionType = type(Union[int, float])
 
 if TYPE_CHECKING:
-    from polars.datatypes.type_aliases import PolarsDataType, PythonDataType, SchemaDict
+    from polars.datatypes.type_aliases import PolarsDataType
+    from polars.datatypes.type_aliases import PythonDataType
+    from polars.datatypes.type_aliases import SchemaDict
     from polars.internals.type_aliases import TimeUnit
 
     if sys.version_info >= (3, 8):
@@ -398,10 +400,8 @@ def maybe_cast(
 ) -> Any:
     """Try casting a value to a value that is valid for the given Polars dtype."""
     # cast el if it doesn't match
-    from polars.utils.convert import (
-        _datetime_to_pl_timestamp,
-        _timedelta_to_pl_timedelta,
-    )
+    from polars.utils.convert import _datetime_to_pl_timestamp
+    from polars.utils.convert import _timedelta_to_pl_timedelta
 
     if isinstance(el, datetime):
         return _datetime_to_pl_timestamp(el, time_unit)

--- a/py-polars/polars/datatypes/type_aliases.py
+++ b/py-polars/polars/datatypes/type_aliases.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 from decimal import Decimal
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    List,
-    Mapping,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Iterable
+from typing import List
+from typing import Mapping
+from typing import Sequence
+from typing import Tuple
+from typing import Type
+from typing import Union
 
 if TYPE_CHECKING:
     import sys

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -6,7 +6,10 @@ from functools import lru_cache
 from importlib import import_module
 from importlib.util import find_spec
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Hashable, cast
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Hashable
+from typing import cast
 
 _FSSPEC_AVAILABLE = True
 _NUMPY_AVAILABLE = True

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -1,17 +1,15 @@
 try:
-    from polars.polars import (
-        ArrowError,
-        ColumnNotFoundError,
-        ComputeError,
-        DuplicateError,
-        InvalidOperationError,
-        NoDataError,
-        PanicException,
-        SchemaError,
-        SchemaFieldNotFoundError,
-        ShapeError,
-        StructFieldNotFoundError,
-    )
+    from polars.polars import ArrowError
+    from polars.polars import ColumnNotFoundError
+    from polars.polars import ComputeError
+    from polars.polars import DuplicateError
+    from polars.polars import InvalidOperationError
+    from polars.polars import NoDataError
+    from polars.polars import PanicException
+    from polars.polars import SchemaError
+    from polars.polars import SchemaFieldNotFoundError
+    from polars.polars import ShapeError
+    from polars.polars import StructFieldNotFoundError
 except ImportError:
     # They are only redefined for documentation purposes
     # when there is no binary yet

--- a/py-polars/polars/internals/__init__.py
+++ b/py-polars/polars/internals/__init__.py
@@ -5,49 +5,47 @@ The modules within `polars.internals` are interdependent. To prevent cyclical im
 they all import from each other via this __init__ file using
 `import polars.internals as pli`. The imports below are being shared across this module.
 """
-from polars.internals.anonymous_scan import (
-    _deser_and_exec,
-    _scan_ipc_fsspec,
-    _scan_parquet_fsspec,
-    _scan_pyarrow_dataset,
-)
+from polars.internals.anonymous_scan import _deser_and_exec
+from polars.internals.anonymous_scan import _scan_ipc_fsspec
+from polars.internals.anonymous_scan import _scan_parquet_fsspec
+from polars.internals.anonymous_scan import _scan_pyarrow_dataset
 from polars.internals.batched import BatchedCsvReader
-from polars.internals.dataframe import DataFrame, wrap_df
-from polars.internals.expr import (
-    Expr,
-    expr_to_lit_or_expr,
-    selection_to_pyexpr_list,
-    wrap_expr,
-)
-from polars.internals.functions import concat, date_range
-from polars.internals.io import (
-    _is_local_file,
-    _prepare_file_arg,
-    _update_columns,
-    read_ipc_schema,
-    read_parquet_schema,
-)
-from polars.internals.lazy_functions import (
-    all,
-    arange,
-    arg_sort_by,
-    arg_where,
-    argsort_by,
-    coalesce,
-    col,
-    collect_all,
-    concat_list,
-    count,
-    element,
-    format,
-    from_epoch,
-    lit,
-    select,
-    struct,
-)
-from polars.internals.lazyframe import LazyFrame, wrap_ldf
-from polars.internals.series import Series, wrap_s
-from polars.internals.whenthen import WhenThen, WhenThenThen, when
+from polars.internals.dataframe import DataFrame
+from polars.internals.dataframe import wrap_df
+from polars.internals.expr import Expr
+from polars.internals.expr import expr_to_lit_or_expr
+from polars.internals.expr import selection_to_pyexpr_list
+from polars.internals.expr import wrap_expr
+from polars.internals.functions import concat
+from polars.internals.functions import date_range
+from polars.internals.io import _is_local_file
+from polars.internals.io import _prepare_file_arg
+from polars.internals.io import _update_columns
+from polars.internals.io import read_ipc_schema
+from polars.internals.io import read_parquet_schema
+from polars.internals.lazy_functions import all
+from polars.internals.lazy_functions import arange
+from polars.internals.lazy_functions import arg_sort_by
+from polars.internals.lazy_functions import arg_where
+from polars.internals.lazy_functions import argsort_by
+from polars.internals.lazy_functions import coalesce
+from polars.internals.lazy_functions import col
+from polars.internals.lazy_functions import collect_all
+from polars.internals.lazy_functions import concat_list
+from polars.internals.lazy_functions import count
+from polars.internals.lazy_functions import element
+from polars.internals.lazy_functions import format
+from polars.internals.lazy_functions import from_epoch
+from polars.internals.lazy_functions import lit
+from polars.internals.lazy_functions import select
+from polars.internals.lazy_functions import struct
+from polars.internals.lazyframe import LazyFrame
+from polars.internals.lazyframe import wrap_ldf
+from polars.internals.series import Series
+from polars.internals.series import wrap_s
+from polars.internals.whenthen import WhenThen
+from polars.internals.whenthen import WhenThenThen
+from polars.internals.whenthen import when
 
 __all__ = [
     "DataFrame",

--- a/py-polars/polars/internals/anonymous_scan.py
+++ b/py-polars/polars/internals/anonymous_scan.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import pickle
 from functools import partial
-from typing import Any, cast
+from typing import Any
+from typing import cast
 
 import polars as pl
 from polars import internals as pli
@@ -58,12 +59,12 @@ def _scan_pyarrow_dataset_impl(
     _filter = None
     if predicate:
         # imports are used by inline python evaluated by `eval`
-        from polars.datatypes import Date, Datetime, Duration  # noqa: F401
-        from polars.utils.convert import (
-            _to_python_datetime,  # noqa: F401
-            _to_python_time,  # noqa: F401
-            _to_python_timedelta,  # noqa: F401
-        )
+        from polars.datatypes import Date  # noqa: F401
+        from polars.datatypes import Datetime  # noqa: F401
+        from polars.datatypes import Duration  # noqa: F401
+        from polars.utils.convert import _to_python_datetime  # noqa: F401
+        from polars.utils.convert import _to_python_time  # noqa: F401
+        from polars.utils.convert import _to_python_timedelta  # noqa: F401
 
         _filter = eval(predicate)
     if n_rows:

--- a/py-polars/polars/internals/batched.py
+++ b/py-polars/polars/internals/batched.py
@@ -2,25 +2,23 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
+from typing import Sequence
 
 import polars.internals as pli
-from polars.datatypes import (
-    N_INFER_DEFAULT,
-    py_type_to_dtype,
-)
-from polars.utils.various import (
-    _prepare_row_count_args,
-    _process_null_values,
-    handle_projection_columns,
-    normalise_filepath,
-)
+from polars.datatypes import N_INFER_DEFAULT
+from polars.datatypes import py_type_to_dtype
+from polars.utils.various import _prepare_row_count_args
+from polars.utils.various import _process_null_values
+from polars.utils.various import handle_projection_columns
+from polars.utils.various import normalise_filepath
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyBatchedCsv
 
 if TYPE_CHECKING:
-    from polars.datatypes import PolarsDataType, SchemaDict
+    from polars.datatypes import PolarsDataType
+    from polars.datatypes import SchemaDict
     from polars.internals.type_aliases import CsvEncoding
 
 

--- a/py-polars/polars/internals/construction.py
+++ b/py-polars/polars/internals/construction.py
@@ -1,65 +1,68 @@
 from __future__ import annotations
 
 import contextlib
-from dataclasses import astuple, is_dataclass
-from datetime import date, datetime, time, timedelta
+from dataclasses import astuple
+from dataclasses import is_dataclass
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 from decimal import Decimal as PyDecimal
 from functools import singledispatch
-from itertools import islice, zip_longest
+from itertools import islice
+from itertools import zip_longest
 from sys import version_info
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generator,
-    Iterable,
-    Mapping,
-    MutableMapping,
-    Sequence,
-    get_type_hints,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Generator
+from typing import Iterable
+from typing import Mapping
+from typing import MutableMapping
+from typing import Sequence
+from typing import get_type_hints
 
 from polars import internals as pli
-from polars.datatypes import (
-    N_INFER_DEFAULT,
-    Categorical,
-    Date,
-    Datetime,
-    Duration,
-    Float32,
-    List,
-    Object,
-    Struct,
-    Time,
-    Unknown,
-    Utf8,
-    dtype_to_py_type,
-    is_polars_dtype,
-    py_type_to_dtype,
-)
-from polars.datatypes.constructor import (
-    numpy_type_to_constructor,
-    numpy_values_and_dtype,
-    polars_type_to_constructor,
-    py_type_to_constructor,
-)
-from polars.dependencies import (
-    _NUMPY_AVAILABLE,
-    _PANDAS_AVAILABLE,
-    _check_for_numpy,
-)
+from polars.datatypes import N_INFER_DEFAULT
+from polars.datatypes import Categorical
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Duration
+from polars.datatypes import Float32
+from polars.datatypes import List
+from polars.datatypes import Object
+from polars.datatypes import Struct
+from polars.datatypes import Time
+from polars.datatypes import Unknown
+from polars.datatypes import Utf8
+from polars.datatypes import dtype_to_py_type
+from polars.datatypes import is_polars_dtype
+from polars.datatypes import py_type_to_dtype
+from polars.datatypes.constructor import numpy_type_to_constructor
+from polars.datatypes.constructor import numpy_values_and_dtype
+from polars.datatypes.constructor import polars_type_to_constructor
+from polars.datatypes.constructor import py_type_to_constructor
+from polars.dependencies import _NUMPY_AVAILABLE
+from polars.dependencies import _PANDAS_AVAILABLE
+from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
-from polars.exceptions import ComputeError, ShapeError
+from polars.exceptions import ComputeError
+from polars.exceptions import ShapeError
 from polars.utils.decorators import deprecated_alias
 from polars.utils.meta import threadpool_size
-from polars.utils.various import _is_generator, arrlen, range_to_series
+from polars.utils.various import _is_generator
+from polars.utils.various import arrlen
+from polars.utils.various import range_to_series
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
-    from polars.polars import PyDataFrame, PySeries
+    from polars.polars import PyDataFrame
+    from polars.polars import PySeries
 
 if TYPE_CHECKING:
-    from polars.datatypes import PolarsDataType, SchemaDefinition, SchemaDict
+    from polars.datatypes import PolarsDataType
+    from polars.datatypes import SchemaDefinition
+    from polars.datatypes import SchemaDict
     from polars.internals.type_aliases import Orientation
 
 if version_info >= (3, 10):

--- a/py-polars/polars/internals/dataframe/__init__.py
+++ b/py-polars/polars/internals/dataframe/__init__.py
@@ -1,4 +1,5 @@
-from polars.internals.dataframe.frame import DataFrame, wrap_df
+from polars.internals.dataframe.frame import DataFrame
+from polars.internals.dataframe.frame import wrap_df
 
 __all__ = [
     "DataFrame",

--- a/py-polars/polars/internals/dataframe/_html.py
+++ b/py-polars/polars/internals/dataframe/_html.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import html
 import os
 from textwrap import dedent
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
+from typing import Iterable
 
 if TYPE_CHECKING:
     from types import TracebackType

--- a/py-polars/polars/internals/dataframe/groupby.py
+++ b/py-polars/polars/internals/dataframe/groupby.py
@@ -1,27 +1,24 @@
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Generic,
-    Iterable,
-    Iterator,
-    TypeVar,
-)
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import Generic
+from typing import Iterable
+from typing import Iterator
+from typing import TypeVar
 
 import polars.internals as pli
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.decorators import deprecated_alias, redirect
+from polars.utils.decorators import deprecated_alias
+from polars.utils.decorators import redirect
 
 if TYPE_CHECKING:
     from datetime import timedelta
 
-    from polars.internals.type_aliases import (
-        ClosedInterval,
-        IntoExpr,
-        RollingInterpolationMethod,
-        StartBy,
-    )
+    from polars.internals.type_aliases import ClosedInterval
+    from polars.internals.type_aliases import IntoExpr
+    from polars.internals.type_aliases import RollingInterpolationMethod
+    from polars.internals.type_aliases import StartBy
 
 # A type variable used to refer to a polars.DataFrame or any subclass of it
 DF = TypeVar("DF", bound="pli.DataFrame")

--- a/py-polars/polars/internals/expr/__init__.py
+++ b/py-polars/polars/internals/expr/__init__.py
@@ -1,9 +1,7 @@
-from polars.internals.expr.expr import (
-    Expr,
-    expr_to_lit_or_expr,
-    selection_to_pyexpr_list,
-    wrap_expr,
-)
+from polars.internals.expr.expr import Expr
+from polars.internals.expr.expr import expr_to_lit_or_expr
+from polars.internals.expr.expr import selection_to_pyexpr_list
+from polars.internals.expr.expr import wrap_expr
 
 __all__ = [
     "Expr",

--- a/py-polars/polars/internals/expr/datetime.py
+++ b/py-polars/polars/internals/expr/datetime.py
@@ -4,14 +4,18 @@ from datetime import time
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
-from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
+from polars.datatypes import DTYPE_TEMPORAL_UNITS
+from polars.datatypes import Date
+from polars.datatypes import Int32
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.decorators import deprecated_alias, redirect
+from polars.utils.decorators import deprecated_alias
+from polars.utils.decorators import redirect
 
 if TYPE_CHECKING:
     from datetime import timedelta
 
-    from polars.internals.type_aliases import EpochTimeUnit, TimeUnit
+    from polars.internals.type_aliases import EpochTimeUnit
+    from polars.internals.type_aliases import TimeUnit
 
 
 @redirect(

--- a/py-polars/polars/internals/expr/expr.py
+++ b/py-polars/polars/internals/expr/expr.py
@@ -5,25 +5,24 @@ import math
 import os
 import random
 import warnings
-from datetime import date, datetime, time, timedelta
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Iterable,
-    NoReturn,
-    Sequence,
-    TypeVar,
-    cast,
-)
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import NoReturn
+from typing import Sequence
+from typing import TypeVar
+from typing import cast
 
 from polars import internals as pli
-from polars.datatypes import (
-    Struct,
-    UInt32,
-    is_polars_dtype,
-    py_type_to_dtype,
-)
+from polars.datatypes import Struct
+from polars.datatypes import UInt32
+from polars.datatypes import is_polars_dtype
+from polars.datatypes import py_type_to_dtype
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 from polars.internals.expr.binary import ExprBinaryNameSpace
@@ -34,7 +33,8 @@ from polars.internals.expr.meta import ExprMetaNameSpace
 from polars.internals.expr.string import ExprStringNameSpace
 from polars.internals.expr.struct import ExprStructNameSpace
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 from polars.utils.meta import threadpool_size
 from polars.utils.various import sphinx_accessor
 
@@ -45,24 +45,26 @@ if TYPE_CHECKING:
     import sys
 
     from polars.datatypes import PolarsDataType
-    from polars.internals.type_aliases import (
-        ApplyStrategy,
-        ClosedInterval,
-        FillNullStrategy,
-        InterpolationMethod,
-        IntoExpr,
-        NullBehavior,
-        PythonLiteral,
-        RankMethod,
-        RollingInterpolationMethod,
-        SearchSortedSide,
-    )
+    from polars.internals.type_aliases import ApplyStrategy
+    from polars.internals.type_aliases import ClosedInterval
+    from polars.internals.type_aliases import FillNullStrategy
+    from polars.internals.type_aliases import InterpolationMethod
+    from polars.internals.type_aliases import IntoExpr
+    from polars.internals.type_aliases import NullBehavior
+    from polars.internals.type_aliases import PythonLiteral
+    from polars.internals.type_aliases import RankMethod
+    from polars.internals.type_aliases import RollingInterpolationMethod
+    from polars.internals.type_aliases import SearchSortedSide
     from polars.polars import PyExpr
 
     if sys.version_info >= (3, 11):
-        from typing import Concatenate, ParamSpec, Self
+        from typing import Concatenate
+        from typing import ParamSpec
+        from typing import Self
     else:
-        from typing_extensions import Concatenate, ParamSpec, Self
+        from typing_extensions import Concatenate
+        from typing_extensions import ParamSpec
+        from typing_extensions import Self
 
     T = TypeVar("T")
     P = ParamSpec("P")

--- a/py-polars/polars/internals/expr/list.py
+++ b/py-polars/polars/internals/expr/list.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
 
 import polars.internals as pli
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
-    from datetime import date, datetime, time
+    from datetime import date
+    from datetime import datetime
+    from datetime import time
 
-    from polars.internals.type_aliases import NullBehavior, ToStructStrategy
+    from polars.internals.type_aliases import NullBehavior
+    from polars.internals.type_aliases import ToStructStrategy
 
 
 class ExprListNameSpace:

--- a/py-polars/polars/internals/expr/string.py
+++ b/py-polars/polars/internals/expr/string.py
@@ -3,17 +3,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import polars.internals as pli
-from polars.datatypes import (
-    DataType,
-    Date,
-    Datetime,
-    Time,
-    is_polars_dtype,
-    py_type_to_dtype,
-)
+from polars.datatypes import DataType
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Time
+from polars.datatypes import is_polars_dtype
+from polars.datatypes import py_type_to_dtype
 
 if TYPE_CHECKING:
-    from polars.datatypes import PolarsDataType, PolarsTemporalType
+    from polars.datatypes import PolarsDataType
+    from polars.datatypes import PolarsTemporalType
     from polars.internals.type_aliases import TransferEncoding
 
 

--- a/py-polars/polars/internals/functions.py
+++ b/py-polars/polars/internals/functions.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import contextlib
 import warnings
-from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Iterable, Sequence, overload
+from datetime import datetime
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from typing import Iterable
+from typing import Sequence
+from typing import overload
 
 from polars import internals as pli
 from polars.datatypes import Date
-from polars.utils.convert import _datetime_to_pl_timestamp, _timedelta_to_pl_duration
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.convert import _datetime_to_pl_timestamp
+from polars.utils.convert import _timedelta_to_pl_duration
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import concat_df as _concat_df
@@ -26,7 +32,9 @@ if TYPE_CHECKING:
     from datetime import date
 
     from polars.datatypes import PolarsDataType
-    from polars.internals.type_aliases import ClosedInterval, ConcatMethod, TimeUnit
+    from polars.internals.type_aliases import ClosedInterval
+    from polars.internals.type_aliases import ConcatMethod
+    from polars.internals.type_aliases import TimeUnit
 
     if sys.version_info >= (3, 8):
         from typing import Literal

--- a/py-polars/polars/internals/io.py
+++ b/py-polars/polars/internals/io.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
 import glob
-from contextlib import contextmanager, suppress
-from io import BytesIO, StringIO
+from contextlib import contextmanager
+from contextlib import suppress
+from io import BytesIO
+from io import StringIO
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    BinaryIO,
-    ContextManager,
-    Iterator,
-    TextIO,
-    overload,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import BinaryIO
+from typing import ContextManager
+from typing import Iterator
+from typing import TextIO
+from typing import overload
 
-from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
+from polars.dependencies import _FSSPEC_AVAILABLE
+from polars.dependencies import fsspec
 from polars.exceptions import NoDataError
 from polars.utils.decorators import deprecated_alias
 from polars.utils.various import normalise_filepath

--- a/py-polars/polars/internals/io_excel.py
+++ b/py-polars/polars/internals/io_excel.py
@@ -2,26 +2,22 @@ from __future__ import annotations
 
 from io import BytesIO
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    Sequence,
-    Tuple,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Sequence
+from typing import Tuple
+from typing import Union
+from typing import overload
 
 import polars.internals as pli
-from polars.datatypes import (
-    FLOAT_DTYPES,
-    INTEGER_DTYPES,
-    NUMERIC_DTYPES,
-    Date,
-    Datetime,
-    Time,
-)
+from polars.datatypes import FLOAT_DTYPES
+from polars.datatypes import INTEGER_DTYPES
+from polars.datatypes import NUMERIC_DTYPES
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Time
 from polars.exceptions import DuplicateError
 
 
@@ -35,12 +31,15 @@ if TYPE_CHECKING:
     from xlsxwriter import Workbook
     from xlsxwriter.worksheet import Worksheet
 
-    from polars.datatypes import OneOrMoreDataTypes, PolarsDataType
+    from polars.datatypes import OneOrMoreDataTypes
+    from polars.datatypes import PolarsDataType
 
     if sys.version_info >= (3, 10):
-        from typing import Literal, TypeAlias
+        from typing import Literal
+        from typing import TypeAlias
     else:
-        from typing_extensions import Literal, TypeAlias
+        from typing_extensions import Literal
+        from typing_extensions import TypeAlias
 
 
 _XL_DEFAULT_FLOAT_FORMAT_ = "#,##0.{zeros};[Red]-#,##0.{zeros}"

--- a/py-polars/polars/internals/lazy_functions.py
+++ b/py-polars/polars/internals/lazy_functions.py
@@ -2,31 +2,36 @@ from __future__ import annotations
 
 import contextlib
 import warnings
-from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import Sequence
+from typing import overload
 
 from polars import internals as pli
-from polars.datatypes import (
-    DTYPE_TEMPORAL_UNITS,
-    Date,
-    Datetime,
-    Duration,
-    Int32,
-    Int64,
-    Struct,
-    Time,
-    UInt32,
-    is_polars_dtype,
-    py_type_to_dtype,
-)
+from polars.datatypes import DTYPE_TEMPORAL_UNITS
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Duration
+from polars.datatypes import Int32
+from polars.datatypes import Int64
+from polars.datatypes import Struct
+from polars.datatypes import Time
+from polars.datatypes import UInt32
+from polars.datatypes import is_polars_dtype
+from polars.datatypes import py_type_to_dtype
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
-from polars.utils.convert import (
-    _datetime_to_pl_timestamp,
-    _time_to_pl_time,
-    _timedelta_to_pl_timedelta,
-)
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.convert import _datetime_to_pl_timestamp
+from polars.utils.convert import _time_to_pl_time
+from polars.utils.convert import _timedelta_to_pl_timedelta
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import arange as pyarange
@@ -52,7 +57,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import max_exprs as _max_exprs
     from polars.polars import min_exprs as _min_exprs
     from polars.polars import pearson_corr as pypearson_corr
-    from polars.polars import py_datetime, py_duration
+    from polars.polars import py_datetime
+    from polars.polars import py_duration
     from polars.polars import reduce as pyreduce
     from polars.polars import repeat as _repeat
     from polars.polars import spearman_rank_corr as pyspearman_rank_corr
@@ -62,14 +68,13 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 if TYPE_CHECKING:
     import sys
 
-    from polars.datatypes import PolarsDataType, SchemaDict
-    from polars.internals.type_aliases import (
-        CorrelationMethod,
-        EpochTimeUnit,
-        IntoExpr,
-        RollingInterpolationMethod,
-        TimeUnit,
-    )
+    from polars.datatypes import PolarsDataType
+    from polars.datatypes import SchemaDict
+    from polars.internals.type_aliases import CorrelationMethod
+    from polars.internals.type_aliases import EpochTimeUnit
+    from polars.internals.type_aliases import IntoExpr
+    from polars.internals.type_aliases import RollingInterpolationMethod
+    from polars.internals.type_aliases import TimeUnit
 
     if sys.version_info >= (3, 8):
         from typing import Literal

--- a/py-polars/polars/internals/lazyframe/__init__.py
+++ b/py-polars/polars/internals/lazyframe/__init__.py
@@ -1,4 +1,5 @@
-from polars.internals.lazyframe.frame import LazyFrame, wrap_ldf
+from polars.internals.lazyframe.frame import LazyFrame
+from polars.internals.lazyframe.frame import wrap_ldf
 
 __all__ = [
     "LazyFrame",

--- a/py-polars/polars/internals/lazyframe/frame.py
+++ b/py-polars/polars/internals/lazyframe/frame.py
@@ -5,58 +5,54 @@ import os
 import subprocess
 import typing
 import warnings
-from datetime import date, datetime, time, timedelta
-from io import BytesIO, StringIO
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from io import BytesIO
+from io import StringIO
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Iterable,
-    NoReturn,
-    Sequence,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import NoReturn
+from typing import Sequence
+from typing import TypeVar
+from typing import overload
 
 from polars import internals as pli
-from polars.datatypes import (
-    DTYPE_TEMPORAL_UNITS,
-    N_INFER_DEFAULT,
-    Boolean,
-    Categorical,
-    Date,
-    Datetime,
-    Duration,
-    Float32,
-    Float64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
-    Time,
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
-    Utf8,
-    py_type_to_dtype,
-)
+from polars.datatypes import DTYPE_TEMPORAL_UNITS
+from polars.datatypes import N_INFER_DEFAULT
+from polars.datatypes import Boolean
+from polars.datatypes import Categorical
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Duration
+from polars.datatypes import Float32
+from polars.datatypes import Float64
+from polars.datatypes import Int8
+from polars.datatypes import Int16
+from polars.datatypes import Int32
+from polars.datatypes import Int64
+from polars.datatypes import Time
+from polars.datatypes import UInt8
+from polars.datatypes import UInt16
+from polars.datatypes import UInt32
+from polars.datatypes import UInt64
+from polars.datatypes import Utf8
+from polars.datatypes import py_type_to_dtype
 from polars.internals import selection_to_pyexpr_list
 from polars.internals.lazyframe.groupby import LazyGroupBy
 from polars.internals.slice import LazyPolarsSlice
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.decorators import (
-    deprecate_nonkeyword_arguments,
-    deprecated_alias,
-    redirect,
-)
-from polars.utils.various import (
-    _in_notebook,
-    _prepare_row_count_args,
-    _process_null_values,
-    normalise_filepath,
-)
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
+from polars.utils.decorators import redirect
+from polars.utils.various import _in_notebook
+from polars.utils.various import _prepare_row_count_args
+from polars.utils.various import _process_null_values
+from polars.utils.various import normalise_filepath
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyLazyFrame
@@ -68,28 +64,30 @@ if TYPE_CHECKING:
 
     import pyarrow as pa
 
-    from polars.datatypes import PolarsDataType, SchemaDefinition, SchemaDict
-    from polars.internals.type_aliases import (
-        AsofJoinStrategy,
-        ClosedInterval,
-        CsvEncoding,
-        FillNullStrategy,
-        FrameInitTypes,
-        IntoExpr,
-        JoinStrategy,
-        Orientation,
-        ParallelStrategy,
-        PolarsExprType,
-        PythonLiteral,
-        RollingInterpolationMethod,
-        StartBy,
-        UniqueKeepStrategy,
-    )
+    from polars.datatypes import PolarsDataType
+    from polars.datatypes import SchemaDefinition
+    from polars.datatypes import SchemaDict
+    from polars.internals.type_aliases import AsofJoinStrategy
+    from polars.internals.type_aliases import ClosedInterval
+    from polars.internals.type_aliases import CsvEncoding
+    from polars.internals.type_aliases import FillNullStrategy
+    from polars.internals.type_aliases import FrameInitTypes
+    from polars.internals.type_aliases import IntoExpr
+    from polars.internals.type_aliases import JoinStrategy
+    from polars.internals.type_aliases import Orientation
+    from polars.internals.type_aliases import ParallelStrategy
+    from polars.internals.type_aliases import PolarsExprType
+    from polars.internals.type_aliases import PythonLiteral
+    from polars.internals.type_aliases import RollingInterpolationMethod
+    from polars.internals.type_aliases import StartBy
+    from polars.internals.type_aliases import UniqueKeepStrategy
 
     if sys.version_info >= (3, 10):
-        from typing import Concatenate, ParamSpec
+        from typing import Concatenate
+        from typing import ParamSpec
     else:
-        from typing_extensions import Concatenate, ParamSpec
+        from typing_extensions import Concatenate
+        from typing_extensions import ParamSpec
 
     if sys.version_info >= (3, 11):
         from typing import Self
@@ -1067,7 +1065,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             return None
 
         if _in_notebook():
-            from IPython.display import SVG, display
+            from IPython.display import SVG
+            from IPython.display import display
 
             return display(SVG(graph))
         else:

--- a/py-polars/polars/internals/lazyframe/groupby.py
+++ b/py-polars/polars/internals/lazyframe/groupby.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Generic, Iterable, TypeVar
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import Generic
+from typing import Iterable
+from typing import TypeVar
 
 import polars.internals as pli
-from polars.internals import expr_to_lit_or_expr, selection_to_pyexpr_list
+from polars.internals import expr_to_lit_or_expr
+from polars.internals import selection_to_pyexpr_list
 from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from polars.datatypes import SchemaDict
-    from polars.internals.type_aliases import IntoExpr, RollingInterpolationMethod
+    from polars.internals.type_aliases import IntoExpr
+    from polars.internals.type_aliases import RollingInterpolationMethod
     from polars.polars import PyLazyGroupBy
 
 LDF = TypeVar("LDF", bound="pli.LazyFrame")

--- a/py-polars/polars/internals/series/__init__.py
+++ b/py-polars/polars/internals/series/__init__.py
@@ -1,4 +1,5 @@
-from polars.internals.series.series import Series, wrap_s
+from polars.internals.series.series import Series
+from polars.internals.series.series import wrap_s
 
 __all__ = [
     "Series",

--- a/py-polars/polars/internals/series/_numpy.py
+++ b/py-polars/polars/internals/series/_numpy.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import ctypes
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+from typing import Any
 
 import numpy as np
 

--- a/py-polars/polars/internals/series/datetime.py
+++ b/py-polars/polars/internals/series/datetime.py
@@ -5,12 +5,17 @@ from typing import TYPE_CHECKING
 import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
 from polars.utils.convert import _to_python_datetime
-from polars.utils.decorators import deprecated_alias, redirect
+from polars.utils.decorators import deprecated_alias
+from polars.utils.decorators import redirect
 
 if TYPE_CHECKING:
-    from datetime import date, datetime, time, timedelta
+    from datetime import date
+    from datetime import datetime
+    from datetime import time
+    from datetime import timedelta
 
-    from polars.internals.type_aliases import EpochTimeUnit, TimeUnit
+    from polars.internals.type_aliases import EpochTimeUnit
+    from polars.internals.type_aliases import TimeUnit
     from polars.polars import PySeries
 
 

--- a/py-polars/polars/internals/series/list.py
+++ b/py-polars/polars/internals/series/list.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
 
 import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
 from polars.utils.decorators import deprecate_nonkeyword_arguments
 
 if TYPE_CHECKING:
-    from datetime import date, datetime, time
+    from datetime import date
+    from datetime import datetime
+    from datetime import time
 
-    from polars.internals.type_aliases import NullBehavior, ToStructStrategy
+    from polars.internals.type_aliases import NullBehavior
+    from polars.internals.type_aliases import ToStructStrategy
     from polars.polars import PySeries
 
 

--- a/py-polars/polars/internals/series/string.py
+++ b/py-polars/polars/internals/series/string.py
@@ -6,7 +6,8 @@ import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    from polars.datatypes import PolarsDataType, PolarsTemporalType
+    from polars.datatypes import PolarsDataType
+    from polars.datatypes import PolarsTemporalType
     from polars.internals.type_aliases import TransferEncoding
     from polars.polars import PySeries
 

--- a/py-polars/polars/internals/series/struct.py
+++ b/py-polars/polars/internals/series/struct.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
+from typing import Sequence
 
 import polars.internals as pli
 from polars.internals.series.utils import expr_dispatch

--- a/py-polars/polars/internals/series/utils.py
+++ b/py-polars/polars/internals/series/utils.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import inspect
 import sys
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import TypeVar
 
 import polars.internals as pli
 from polars.datatypes import dtype_to_ffiname

--- a/py-polars/polars/internals/type_aliases.py
+++ b/py-polars/polars/internals/type_aliases.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 import sys
-from datetime import date, datetime, time, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Mapping, Sequence, Union
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Mapping
+from typing import Sequence
+from typing import Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal

--- a/py-polars/polars/internals/whenthen.py
+++ b/py-polars/polars/internals/whenthen.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import typing
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Iterable
 
 from polars import internals as pli
 
@@ -10,7 +12,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import when as pywhen
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import PolarsExprType, PythonLiteral
+    from polars.internals.type_aliases import PolarsExprType
+    from polars.internals.type_aliases import PythonLiteral
 
 
 class WhenThenThen:

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -1,15 +1,23 @@
 """Functions for reading data."""
 
 from polars.io.avro import read_avro
-from polars.io.csv import read_csv, read_csv_batched, scan_csv
-from polars.io.database import read_database, read_sql
-from polars.io.delta import read_delta, scan_delta
+from polars.io.csv import read_csv
+from polars.io.csv import read_csv_batched
+from polars.io.csv import scan_csv
+from polars.io.database import read_database
+from polars.io.database import read_sql
+from polars.io.delta import read_delta
+from polars.io.delta import scan_delta
 from polars.io.excel import read_excel
-from polars.io.ipc import read_ipc, scan_ipc
+from polars.io.ipc import read_ipc
+from polars.io.ipc import scan_ipc
 from polars.io.json import read_json
-from polars.io.ndjson import read_ndjson, scan_ndjson
-from polars.io.parquet import read_parquet, scan_parquet
-from polars.io.pyarrow_dataset import scan_ds, scan_pyarrow_dataset
+from polars.io.ndjson import read_ndjson
+from polars.io.ndjson import scan_ndjson
+from polars.io.parquet import read_parquet
+from polars.io.parquet import scan_parquet
+from polars.io.pyarrow_dataset import scan_ds
+from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 
 __all__ = [
     "read_avro",

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, BinaryIO
+from typing import TYPE_CHECKING
+from typing import BinaryIO
 
 from polars.internals import DataFrame
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from io import BytesIO

--- a/py-polars/polars/io/csv.py
+++ b/py-polars/polars/io/csv.py
@@ -1,30 +1,33 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    BinaryIO,
-    Callable,
-    Mapping,
-    Sequence,
-    TextIO,
-    cast,
-)
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import BinaryIO
+from typing import Callable
+from typing import Mapping
+from typing import Sequence
+from typing import TextIO
+from typing import cast
 
 import polars.internals as pli
 from polars.convert import from_arrow
-from polars.datatypes import N_INFER_DEFAULT, Utf8
-from polars.internals import DataFrame, LazyFrame
+from polars.datatypes import N_INFER_DEFAULT
+from polars.datatypes import Utf8
+from polars.internals import DataFrame
+from polars.internals import LazyFrame
 from polars.internals.batched import BatchedCsvReader
 from polars.internals.io import _prepare_file_arg
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
-from polars.utils.various import handle_projection_columns, normalise_filepath
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
+from polars.utils.various import handle_projection_columns
+from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
     from io import BytesIO
 
-    from polars.datatypes import PolarsDataType, SchemaDict
+    from polars.datatypes import PolarsDataType
+    from polars.datatypes import SchemaDict
     from polars.internals.type_aliases import CsvEncoding
 
 

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+from typing import Any
 
 from polars.convert import from_arrow
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     import polars.internals as pli

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+from typing import Any
 
 from polars.convert import from_arrow
-from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
+from polars.dependencies import _DELTALAKE_AVAILABLE
+from polars.dependencies import deltalake
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from polars.dependencies import pyarrow as pa
-    from polars.internals import DataFrame, LazyFrame
+    from polars.internals import DataFrame
+    from polars.internals import LazyFrame
 
 
 @deprecate_nonkeyword_arguments()
@@ -329,7 +333,8 @@ def scan_delta(
 
 
 def _resolve_delta_lake_uri(table_uri: str) -> tuple[str, str, str]:
-    from urllib.parse import ParseResult, urlparse
+    from urllib.parse import ParseResult
+    from urllib.parse import urlparse
 
     parsed_result = urlparse(table_uri)
     scheme = parsed_result.scheme

--- a/py-polars/polars/io/excel.py
+++ b/py-polars/polars/io/excel.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from io import StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO, overload
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import BinaryIO
+from typing import overload
 
 from polars.io.csv import read_csv
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/ipc.py
+++ b/py-polars/polars/io/ipc.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, BinaryIO
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import BinaryIO
 
 from polars.dependencies import _PYARROW_AVAILABLE
-from polars.internals import DataFrame, LazyFrame
+from polars.internals import DataFrame
+from polars.internals import LazyFrame
 from polars.internals.io import _prepare_file_arg
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 if TYPE_CHECKING:
     from io import BytesIO

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polars.datatypes import N_INFER_DEFAULT
-from polars.internals import DataFrame, LazyFrame
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.internals import DataFrame
+from polars.internals import LazyFrame
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/parquet.py
+++ b/py-polars/polars/io/parquet.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import BinaryIO
 
 from polars.convert import from_arrow
 from polars.dependencies import _PYARROW_AVAILABLE
-from polars.internals import DataFrame, LazyFrame
+from polars.internals import DataFrame
+from polars.internals import LazyFrame
 from polars.internals.io import _prepare_file_arg
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:

--- a/py-polars/polars/testing/__init__.py
+++ b/py-polars/polars/testing/__init__.py
@@ -1,10 +1,8 @@
-from polars.testing.asserts import (
-    assert_frame_equal,
-    assert_frame_equal_local_categoricals,
-    assert_frame_not_equal,
-    assert_series_equal,
-    assert_series_not_equal,
-)
+from polars.testing.asserts import assert_frame_equal
+from polars.testing.asserts import assert_frame_equal_local_categoricals
+from polars.testing.asserts import assert_frame_not_equal
+from polars.testing.asserts import assert_series_equal
+from polars.testing.asserts import assert_series_not_equal
 
 __all__ = [
     "assert_series_equal",

--- a/py-polars/polars/testing/_parametric.py
+++ b/py-polars/polars/testing/_parametric.py
@@ -4,57 +4,59 @@ import os
 import random
 import warnings
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from math import isfinite
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Sequence
 
 from hypothesis import settings
-from hypothesis.errors import InvalidArgument, NonInteractiveExampleWarning
-from hypothesis.strategies import (
-    booleans,
-    composite,
-    dates,
-    datetimes,
-    floats,
-    from_type,
-    integers,
-    lists,
-    sampled_from,
-    text,
-    timedeltas,
-    times,
-)
+from hypothesis.errors import InvalidArgument
+from hypothesis.errors import NonInteractiveExampleWarning
+from hypothesis.strategies import booleans
+from hypothesis.strategies import composite
+from hypothesis.strategies import dates
+from hypothesis.strategies import datetimes
+from hypothesis.strategies import floats
+from hypothesis.strategies import from_type
+from hypothesis.strategies import integers
+from hypothesis.strategies import lists
+from hypothesis.strategies import sampled_from
+from hypothesis.strategies import text
+from hypothesis.strategies import timedeltas
+from hypothesis.strategies import times
 from hypothesis.strategies._internal.utils import defines_strategy
 
 import polars.internals as pli
-from polars.datatypes import (
-    Boolean,
-    Categorical,
-    Date,
-    Datetime,
-    Duration,
-    Float32,
-    Float64,
-    Int8,
-    Int16,
-    Int32,
-    Int64,
-    Time,
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
-    Utf8,
-    is_polars_dtype,
-    py_type_to_dtype,
-)
+from polars.datatypes import Boolean
+from polars.datatypes import Categorical
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Duration
+from polars.datatypes import Float32
+from polars.datatypes import Float64
+from polars.datatypes import Int8
+from polars.datatypes import Int16
+from polars.datatypes import Int32
+from polars.datatypes import Int64
+from polars.datatypes import Time
+from polars.datatypes import UInt8
+from polars.datatypes import UInt16
+from polars.datatypes import UInt32
+from polars.datatypes import UInt64
+from polars.datatypes import Utf8
+from polars.datatypes import is_polars_dtype
+from polars.datatypes import py_type_to_dtype
 from polars.string_cache import StringCache
 from polars.testing.asserts import is_categorical_dtype
 
 if TYPE_CHECKING:
-    from hypothesis.strategies import DrawFn, SearchStrategy
+    from hypothesis.strategies import DrawFn
+    from hypothesis.strategies import SearchStrategy
 
-    from polars.datatypes import OneOrMoreDataTypes, PolarsDataType
+    from polars.datatypes import OneOrMoreDataTypes
+    from polars.datatypes import PolarsDataType
 
 
 # Default profile (eg: running locally)

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -4,16 +4,16 @@ import textwrap
 from typing import Any
 
 import polars.internals as pli
-from polars.datatypes import (
-    Boolean,
-    Categorical,
-    DataTypeClass,
-    Float32,
-    Float64,
-    dtype_to_py_type,
-)
-from polars.exceptions import ComputeError, InvalidAssert
-from polars.utils.decorators import deprecate_nonkeyword_arguments, deprecated_alias
+from polars.datatypes import Boolean
+from polars.datatypes import Categorical
+from polars.datatypes import DataTypeClass
+from polars.datatypes import Float32
+from polars.datatypes import Float64
+from polars.datatypes import dtype_to_py_type
+from polars.exceptions import ComputeError
+from polars.exceptions import InvalidAssert
+from polars.utils.decorators import deprecate_nonkeyword_arguments
+from polars.utils.decorators import deprecated_alias
 
 
 @deprecate_nonkeyword_arguments()

--- a/py-polars/polars/testing/parametric.py
+++ b/py-polars/polars/testing/parametric.py
@@ -3,13 +3,11 @@ from typing import Any
 from polars.dependencies import _HYPOTHESIS_AVAILABLE
 
 if _HYPOTHESIS_AVAILABLE:
-    from polars.testing._parametric import (
-        column,
-        columns,
-        dataframes,
-        series,
-        strategy_dtypes,
-    )
+    from polars.testing._parametric import column
+    from polars.testing._parametric import columns
+    from polars.testing._parametric import dataframes
+    from polars.testing._parametric import series
+    from polars.testing._parametric import strategy_dtypes
 else:
 
     def __getattr__(*args: Any, **kwargs: Any) -> Any:

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -4,16 +4,16 @@ Utility functions.
 Functions that are part of the public API are re-exported here.
 """
 from polars.utils.build_info import build_info
-from polars.utils.convert import (
-    _date_to_pl_date,
-    _time_to_pl_time,
-    _timedelta_to_pl_timedelta,
-    _to_python_datetime,
-    _to_python_decimal,
-    _to_python_time,
-    _to_python_timedelta,
-)
-from polars.utils.meta import get_idx_type, get_index_type, threadpool_size
+from polars.utils.convert import _date_to_pl_date
+from polars.utils.convert import _time_to_pl_time
+from polars.utils.convert import _timedelta_to_pl_timedelta
+from polars.utils.convert import _to_python_datetime
+from polars.utils.convert import _to_python_decimal
+from polars.utils.convert import _to_python_time
+from polars.utils.convert import _to_python_timedelta
+from polars.utils.meta import get_idx_type
+from polars.utils.meta import get_index_type
+from polars.utils.meta import threadpool_size
 from polars.utils.show_versions import show_versions
 
 __all__ = [

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 import functools
 import sys
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from datetime import timezone
 from decimal import Context
-from typing import TYPE_CHECKING, Any, Callable, Sequence, TypeVar, overload
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Sequence
+from typing import TypeVar
+from typing import overload
 
-from polars.datatypes import Date, Datetime
-from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars.dependencies import zoneinfo
 
 # This code block is due to a typing issue with backports.zoneinfo package:
 # https://github.com/pganssle/zoneinfo/issues/125
@@ -24,7 +34,8 @@ if sys.version_info >= (3, 11):
 
 if TYPE_CHECKING:
     from collections.abc import Reversible
-    from datetime import date, tzinfo
+    from datetime import date
+    from datetime import tzinfo
     from decimal import Decimal
 
     from polars.datatypes import PolarsDataType

--- a/py-polars/polars/utils/decorators.py
+++ b/py-polars/polars/utils/decorators.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import functools
 import inspect
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import TypeVar
 
 if TYPE_CHECKING:
     import sys

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -4,11 +4,18 @@ import contextlib
 import os
 import re
 import sys
-from collections.abc import MappingView, Sized
-from typing import TYPE_CHECKING, Any, Generator, Iterable, Sequence, TypeVar
+from collections.abc import MappingView
+from collections.abc import Sized
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Generator
+from typing import Iterable
+from typing import Sequence
+from typing import TypeVar
 
 import polars.internals as pli
-from polars.datatypes import Int64, is_polars_dtype
+from polars.datatypes import Int64
+from polars.datatypes import is_polars_dtype
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyExpr
@@ -27,9 +34,11 @@ if TYPE_CHECKING:
     from polars.internals.type_aliases import SizeUnit
 
     if sys.version_info >= (3, 10):
-        from typing import ParamSpec, TypeGuard
+        from typing import ParamSpec
+        from typing import TypeGuard
     else:
-        from typing_extensions import ParamSpec, TypeGuard
+        from typing_extensions import ParamSpec
+        from typing_extensions import TypeGuard
 
     P = ParamSpec("P")
     T = TypeVar("T")

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -158,6 +158,9 @@ ignore = [
 [tool.ruff.pycodestyle]
 max-doc-length = 88
 
+[tool.ruff.isort]
+force-single-line = true
+
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"
 

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -35,7 +35,9 @@ import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Iterator
 
 import polars
 

--- a/py-polars/tests/parametric/test_dataframe.py
+++ b/py-polars/tests/parametric/test_dataframe.py
@@ -3,12 +3,15 @@
 # ----------------------------------------------------
 from __future__ import annotations
 
-from hypothesis import example, given, settings
+from hypothesis import example
+from hypothesis import given
+from hypothesis import settings
 from hypothesis.strategies import integers
 
 import polars as pl
 from polars.testing import assert_frame_equal
-from polars.testing.parametric import column, dataframes
+from polars.testing.parametric import column
+from polars.testing.parametric import dataframes
 
 
 @given(df=dataframes())

--- a/py-polars/tests/parametric/test_lazyframe.py
+++ b/py-polars/tests/parametric/test_lazyframe.py
@@ -5,7 +5,8 @@ from hypothesis import given
 from hypothesis.strategies import integers
 
 import polars as pl
-from polars.testing.parametric import column, dataframes
+from polars.testing.parametric import column
+from polars.testing.parametric import dataframes
 
 
 @given(

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -7,8 +7,11 @@ from decimal import Decimal
 from typing import no_type_check
 
 import numpy as np
-from hypothesis import given, settings
-from hypothesis.strategies import booleans, floats, sampled_from
+from hypothesis import given
+from hypothesis import settings
+from hypothesis.strategies import booleans
+from hypothesis.strategies import floats
+from hypothesis.strategies import sampled_from
 from numpy.testing import assert_array_equal
 
 import polars as pl

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -7,18 +7,18 @@ import warnings
 from typing import Any
 
 import pytest
-from hypothesis import given, settings
-from hypothesis.errors import InvalidArgument, NonInteractiveExampleWarning
+from hypothesis import given
+from hypothesis import settings
+from hypothesis.errors import InvalidArgument
+from hypothesis.errors import NonInteractiveExampleWarning
 from hypothesis.strategies import sampled_from
 
 import polars as pl
-from polars.testing.parametric import (
-    column,
-    columns,
-    dataframes,
-    series,
-    strategy_dtypes,
-)
+from polars.testing.parametric import column
+from polars.testing.parametric import columns
+from polars.testing.parametric import dataframes
+from polars.testing.parametric import series
+from polars.testing.parametric import strategy_dtypes
 
 # TODO: make dtype categories flexible and available from datatypes module
 TEMPORAL_DTYPES = [pl.Datetime, pl.Date, pl.Time, pl.Duration]

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import List, cast
+from typing import List
+from typing import cast
 
 import pytest
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time
+from datetime import date
+from datetime import datetime
+from datetime import time
 
 import pandas as pd
 import pytest

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 import io
 import sys
-from datetime import date, datetime, time, timedelta, timezone
-from typing import TYPE_CHECKING, cast, no_type_check
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from datetime import timezone
+from typing import TYPE_CHECKING
+from typing import cast
+from typing import no_type_check
 
 import numpy as np
 import pandas as pd
@@ -11,13 +17,14 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import DATETIME_DTYPES, DTYPE_TEMPORAL_UNITS, TEMPORAL_DTYPES
-from polars.exceptions import ComputeError, PanicException
-from polars.testing import (
-    assert_frame_equal,
-    assert_series_equal,
-    assert_series_not_equal,
-)
+from polars.datatypes import DATETIME_DTYPES
+from polars.datatypes import DTYPE_TEMPORAL_UNITS
+from polars.datatypes import TEMPORAL_DTYPES
+from polars.exceptions import ComputeError
+from polars.exceptions import PanicException
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
+from polars.testing import assert_series_not_equal
 
 if TYPE_CHECKING:
     from polars.datatypes import PolarsTemporalType

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -7,7 +7,11 @@ import tempfile
 import textwrap
 import typing
 import zlib
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from datetime import timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,12 +19,11 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, NoDataError
-from polars.testing import (
-    assert_frame_equal,
-    assert_frame_equal_local_categoricals,
-    assert_series_equal,
-)
+from polars.exceptions import ComputeError
+from polars.exceptions import NoDataError
+from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal_local_categoricals
+from polars.testing import assert_series_equal
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -12,11 +12,9 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import (
-        DbReadEngine,
-        DbWriteEngine,
-        DbWriteMode,
-    )
+    from polars.internals.type_aliases import DbReadEngine
+    from polars.internals.type_aliases import DbWriteEngine
+    from polars.internals.type_aliases import DbWriteMode
 
 
 @pytest.fixture()

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -6,7 +6,8 @@ import pyarrow.fs
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_frame_not_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_not_equal
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from datetime import date
 from io import BytesIO
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -10,7 +10,8 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_frame_equal_local_categoricals
+from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal_local_categoricals
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import IpcCompression

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_frame_equal_local_categoricals
+from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal_local_categoricals
 
 
 @pytest.mark.parametrize("buf", [io.BytesIO(), io.StringIO()])

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+from typing import Any
 
 import pandas as pd
 import pytest

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -5,7 +5,8 @@ import os.path
 from typing import cast
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_copy() -> None:

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -15,7 +15,8 @@ import pyarrow.parquet as pq
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_frame_equal_local_categoricals
+from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal_local_categoricals
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import ParquetCompression

--- a/py-polars/tests/unit/io/test_pickle.py
+++ b/py-polars/tests/unit/io/test_pickle.py
@@ -4,7 +4,8 @@ import io
 import pickle
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_pickle() -> None:

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import sys
 import tempfile
 import typing
-from datetime import date, datetime, time
+from datetime import date
+from datetime import datetime
+from datetime import time
 from pathlib import Path
 
 import pyarrow.dataset as ds

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import pytest

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import typing
-from datetime import date, datetime
+from datetime import date
+from datetime import datetime
 
 import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_list_arr_get() -> None:

--- a/py-polars/tests/unit/namespaces/test_string.py
+++ b/py-polars/tests/unit/namespaces/test_string.py
@@ -5,7 +5,8 @@ from typing import cast
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_str_slice() -> None:

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -6,7 +6,10 @@ This method gets its own module due to its complexity.
 from __future__ import annotations
 
 import sys
-from datetime import date, datetime, timedelta, timezone
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from typing import TYPE_CHECKING
 
 import pytest

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -1,5 +1,6 @@
 import typing
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 
 import numpy as np
 import pytest

--- a/py-polars/tests/unit/operations/test_apply.py
+++ b/py-polars/tests/unit/operations/test_apply.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
-from datetime import date, datetime, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
 from functools import reduce
-from typing import Sequence, no_type_check
+from typing import Sequence
+from typing import no_type_check
 
 import numpy as np
 

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -1,5 +1,7 @@
 import typing
-from datetime import date, datetime, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
 
 import numpy as np
 import pytest

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pyarrow as pa
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_explode_string() -> None:

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from typing import Any
 
 import pytest
@@ -14,7 +15,8 @@ else:
     from backports.zoneinfo._zoneinfo import ZoneInfo
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_groupby() -> None:

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -9,7 +9,8 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
     from polars.internals.type_aliases import JoinStrategy

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import sys
 import typing
-from datetime import date, datetime, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import pytest

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import random
 import string
-from datetime import date, datetime
+from datetime import date
+from datetime import datetime
 from typing import Any
 
 import numpy as np

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -4,7 +4,8 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_over_args() -> None:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import typing
-from datetime import date, datetime, timezone
+from datetime import date
+from datetime import datetime
+from datetime import timezone
 from decimal import Decimal
 from random import shuffle
 from typing import Any
@@ -12,7 +14,8 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_init_dict() -> None:

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import pickle
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 
 import pytest
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3,28 +3,37 @@ from __future__ import annotations
 import sys
 import textwrap
 import typing
-from datetime import date, datetime, time, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 from decimal import Decimal
 from io import BytesIO
-from operator import floordiv, truediv
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, cast
+from operator import floordiv
+from operator import truediv
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Iterator
+from typing import Sequence
+from typing import cast
 
 import numpy as np
 import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import DTYPE_TEMPORAL_UNITS, INTEGER_DTYPES
+from polars.datatypes import DTYPE_TEMPORAL_UNITS
+from polars.datatypes import INTEGER_DTYPES
 from polars.internals.construction import iterable_to_pydf
-from polars.testing import (
-    assert_frame_equal,
-    assert_frame_not_equal,
-    assert_series_equal,
-)
+from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_not_equal
+from polars.testing import assert_series_equal
 from polars.testing.parametric import columns
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import JoinStrategy, UniqueKeepStrategy
+    from polars.internals.type_aliases import JoinStrategy
+    from polars.internals.type_aliases import UniqueKeepStrategy
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import io
 import typing
-from datetime import date, datetime, time, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 
 import numpy as np
 import pytest

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import random
 import sys
 import typing
-from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+from typing import cast
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
@@ -17,15 +20,14 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.datatypes import (
-    DATETIME_DTYPES,
-    DURATION_DTYPES,
-    FLOAT_DTYPES,
-    INTEGER_DTYPES,
-    NUMERIC_DTYPES,
-    TEMPORAL_DTYPES,
-)
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.datatypes import DATETIME_DTYPES
+from polars.datatypes import DURATION_DTYPES
+from polars.datatypes import FLOAT_DTYPES
+from polars.datatypes import INTEGER_DTYPES
+from polars.datatypes import NUMERIC_DTYPES
+from polars.datatypes import TEMPORAL_DTYPES
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_col_select() -> None:

--- a/py-polars/tests/unit/test_fmt.py
+++ b/py-polars/tests/unit/test_fmt.py
@@ -1,4 +1,5 @@
-from typing import Any, List
+from typing import Any
+from typing import List
 
 import pytest
 

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -6,7 +6,8 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_date_datetime() -> None:

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import typing
-from datetime import date, datetime
-from typing import Any, cast, no_type_check
+from datetime import date
+from datetime import datetime
+from typing import Any
+from typing import cast
+from typing import no_type_check
 
 import numpy as np
 import pandas as pd

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date
+from datetime import datetime
 from functools import reduce
 from inspect import signature
 from operator import add
 from string import ascii_letters
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
 
 import numpy as np
 import pytest
 
 import polars as pl
-from polars import lit, when
+from polars import lit
+from polars import when
 from polars.datatypes import NUMERIC_DTYPES
 from polars.testing import assert_frame_equal
 from polars.testing.asserts import assert_series_equal

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -1,5 +1,7 @@
 import typing
-from datetime import date, datetime, timedelta
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
 
 import numpy as np
 

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from typing import Any
 
 import numpy as np

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -1,7 +1,8 @@
 import pytest
 
 import polars as pl
-from polars.exceptions import NoRowsReturned, TooManyRowsReturned
+from polars.exceptions import NoRowsReturned
+from polars.exceptions import TooManyRowsReturned
 
 
 def test_row_tuple() -> None:

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import pickle
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 
 import polars as pl
 from polars.testing import assert_series_equal

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import math
-from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Iterator, cast
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Iterator
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -10,23 +16,23 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.datatypes import (
-    Date,
-    Datetime,
-    Field,
-    Float64,
-    Int32,
-    Int64,
-    Time,
-    UInt32,
-    UInt64,
-)
+from polars.datatypes import Date
+from polars.datatypes import Datetime
+from polars.datatypes import Field
+from polars.datatypes import Float64
+from polars.datatypes import Int32
+from polars.datatypes import Int64
+from polars.datatypes import Time
+from polars.datatypes import UInt32
+from polars.datatypes import UInt64
 from polars.exceptions import ShapeError
 from polars.internals.construction import iterable_to_pyseries
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.internals.type_aliases import EpochTimeUnit, TimeUnit
+    from polars.internals.type_aliases import EpochTimeUnit
+    from polars.internals.type_aliases import TimeUnit
 
 
 def test_cum_agg() -> None:
@@ -1603,7 +1609,10 @@ def test_comparisons_bool_series_to_int() -> None:
     with pytest.raises(ValueError, match=match):
         srs_bool * 1
 
-    from operator import ge, gt, le, lt
+    from operator import ge
+    from operator import gt
+    from operator import le
+    from operator import lt
 
     for op in (ge, gt, le, lt):
         for scalar in (0, 1.0, True, False):

--- a/py-polars/tests/unit/test_streaming.py
+++ b/py-polars/tests/unit/test_streaming.py
@@ -6,7 +6,8 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
 
 
 def test_streaming_groupby_types() -> None:

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -4,11 +4,9 @@ import pytest
 
 import polars as pl
 from polars.exceptions import InvalidAssert
-from polars.testing import (
-    assert_frame_equal,
-    assert_series_equal,
-    assert_series_not_equal,
-)
+from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal
+from polars.testing import assert_series_not_equal
 
 
 def test_compare_series_value_mismatch() -> None:

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
 import inspect
-from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 
 import polars as pl
-from polars.utils.convert import (
-    _date_to_pl_date,
-    _datetime_to_pl_timestamp,
-    _time_to_pl_time,
-    _timedelta_to_pl_duration,
-    _timedelta_to_pl_timedelta,
-)
+from polars.utils.convert import _date_to_pl_date
+from polars.utils.convert import _datetime_to_pl_timestamp
+from polars.utils.convert import _time_to_pl_time
+from polars.utils.convert import _timedelta_to_pl_duration
+from polars.utils.convert import _timedelta_to_pl_timedelta
 from polars.utils.decorators import deprecate_nonkeyword_arguments
 from polars.utils.various import parse_version
 


### PR DESCRIPTION
This is mostly a matter of taste, but there's some benefits to this style of imports.

It's a simple autoformat option and I have it enabled in all my other projects, so figured I'd throw it out there to see what you guys think. If you think _"nah"_, no hard feelings 😄 

Pros:
* Fewer merge conflicts. The main benefit of this change. Explained [here](https://github.com/asottile/reorder_python_imports#why-this-style).
* Easier to move individual imports in/out of TYPE_CHECKING blocks, 
* Import blocks are more uniform, which can improve readability

Cons:
* A bit more verbose. As you can see, this adds about 190 lines of code. Which is not too bad.
  * Imports that used to fit on one line now require a separate line for each import
  * Imports that were spread out over multiple lines now require 2 **fewer** lines
* Could be viewed as code duplication by purists
* Takes a few more bytes

This will gather conflicts real quick, but rebasing is super easy (all automated formatting), so no rush in merging this.